### PR TITLE
Made all interfaces generic to the view-holder

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.4'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
 

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: 'com.android.application'
 
+ext {
+    android_support_version = '25.3.1'
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
     defaultConfig {
         applicationId "io.huannguyen.swipeablerv"
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -21,8 +25,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
+    compile "com.android.support:appcompat-v7:$android_support_version"
+    compile "com.android.support:recyclerview-v7:$android_support_version"
     compile project(':swipeable-rv')
     testCompile 'junit:junit:4.12'
 }

--- a/demo/src/main/java/io/huannguyen/swipeablerv/demo/SampleAdapter.java
+++ b/demo/src/main/java/io/huannguyen/swipeablerv/demo/SampleAdapter.java
@@ -1,33 +1,31 @@
 package io.huannguyen.swipeablerv.demo;
 
-import android.support.v7.widget.RecyclerView.ViewHolder;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import io.huannguyen.swipeablerv.adapter.StandardSWAdapter;
 
 import java.util.List;
-
-import io.huannguyen.swipeablerv.adapter.StandardSWAdapter;
 
 /**
  * Created by huannguyen
  */
 
-public class SampleAdapter extends StandardSWAdapter<String> {
+public class SampleAdapter extends StandardSWAdapter<String, SampleViewHolder> {
 
     public SampleAdapter(List<String> reminderList) {
         super(reminderList);
     }
 
     @Override
-    public ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+    public SampleViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
         View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.item_view, parent, false);
         return new io.huannguyen.swipeablerv.demo.SampleViewHolder(view);
     }
 
     @Override
-    public void onBindViewHolder(ViewHolder holder, int position) {
-        ((io.huannguyen.swipeablerv.demo.SampleViewHolder)holder).initData(mItems.get(position));
+    public void onBindViewHolder(SampleViewHolder holder, int position) {
+        holder.initData(mItems.get(position));
     }
 
     @Override

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 28 10:00:20 PST 2015
+#Mon Jun 12 17:27:00 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-milestone-1-all.zip

--- a/swipeable-rv/build.gradle
+++ b/swipeable-rv/build.gradle
@@ -13,7 +13,8 @@ ext {
     siteUrl = 'https://github.com/huan-nguyen/SwipeableRV'
     gitUrl = 'https://github.com/huan-nguyen/SwipeableRV.git'
 
-    libraryVersion = '1.0.2'
+    libraryVersion = '1.1.0'
+    android_support_version = '25.3.1'
 
     developerId = 'huannguyen'
     developerName = 'Huan Nguyen'
@@ -25,14 +26,14 @@ ext {
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.3"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 10
-        targetSdkVersion 23
+        targetSdkVersion 25
         versionCode 1
-        versionName "1.0.2"
+        versionName "1.1.0"
     }
     buildTypes {
         release {
@@ -44,8 +45,8 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:23.4.0'
-    compile 'com.android.support:recyclerview-v7:23.4.0'
-    compile 'com.android.support:design:23.4.0'
+    compile "com.android.support:appcompat-v7:$android_support_version"
+    compile "com.android.support:recyclerview-v7:$android_support_version"
+    compile "com.android.support:design:$android_support_version"
 }
 apply from: 'bintray.gradle'

--- a/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/SWItemDelegate.java
+++ b/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/SWItemDelegate.java
@@ -4,7 +4,7 @@ package io.huannguyen.swipeablerv;
  * Created by huannguyen
  */
 
-public interface SWItemDelegate<T> {
+public interface SWItemDelegate<TItem> {
 
     /**
      * Look for an item that matches an adapter position
@@ -14,7 +14,7 @@ public interface SWItemDelegate<T> {
      *
      * @return Item being looked for
      */
-    T getItemAtAdapterPosition(int adapterPosition);
+    TItem getItemAtAdapterPosition(int adapterPosition);
 
     /**
      * Remove an item given a adapter position
@@ -32,5 +32,5 @@ public interface SWItemDelegate<T> {
      * @param adapterPosition
      *         adapter position
      */
-    void addItemWithAdapterPosition(T item, int adapterPosition);
+    void addItemWithAdapterPosition(TItem item, int adapterPosition);
 }

--- a/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/SWItemRemovalListener.java
+++ b/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/SWItemRemovalListener.java
@@ -6,7 +6,7 @@ import io.huannguyen.swipeablerv.view.SWRecyclerView;
  * Created by huannguyen
  */
 
-public interface SWItemRemovalListener<T> {
+public interface SWItemRemovalListener<TItem> {
     /**
      * Method invoked when an item is temporarily removed from a {@link SWRecyclerView}.
      * <p>
@@ -17,7 +17,7 @@ public interface SWItemRemovalListener<T> {
      * @param position
      *         The position of the item being temporarily removed
      */
-    void onItemTemporarilyRemoved(T item, int position);
+    void onItemTemporarilyRemoved(TItem item, int position);
 
     /**
      * Method invoked when it is no longer possible to add the previously removed item back into a {@link SWRecyclerView}.
@@ -26,7 +26,7 @@ public interface SWItemRemovalListener<T> {
      *
      * @param item    The item being permanently removed
      */
-    void onItemPermanentlyRemoved(T item);
+    void onItemPermanentlyRemoved(TItem item);
 
     /**
      * Method invoked when an item associated to the given view holder is added back to a {@link SWRecyclerView}.
@@ -36,5 +36,5 @@ public interface SWItemRemovalListener<T> {
      * @param position
      *         The position of the item being added back
      */
-    void onItemAddedBack(T item, int position);
+    void onItemAddedBack(TItem item, int position);
 }

--- a/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/adapter/DelegateSWAdapter.java
+++ b/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/adapter/DelegateSWAdapter.java
@@ -32,21 +32,21 @@ import io.huannguyen.swipeablerv.utils.ResourceUtils;
  * To have more flexibility, you can take this class and {@link StandardSWAdapter} as references
  * and build you own implementation of the {@link SWAdapter} interface.
  */
-public abstract class DelegateSWAdapter<T> extends RecyclerView.Adapter<ViewHolder>
-        implements SWAdapter<T> {
+public abstract class DelegateSWAdapter<TItem, TViewHolder extends ViewHolder> extends RecyclerView.Adapter<TViewHolder>
+        implements SWAdapter<TItem, TViewHolder> {
 
-    protected SWItemDelegate<T> mItemDelegate;
-    protected SWItemRemovalListener<T> mItemRemovalListener;
+    protected SWItemDelegate<TItem> mItemDelegate;
+    protected SWItemRemovalListener<TItem> mItemRemovalListener;
     protected SWSnackBarDataProvider mSnackBarDataProvider;
 
-    protected DelegateSWAdapter(@NonNull SWItemDelegate<T> itemDelegate) {
+    protected DelegateSWAdapter(@NonNull SWItemDelegate<TItem> itemDelegate) {
         mItemDelegate = itemDelegate;
     }
 
     @Override
-    public void onItemCleared(final ViewHolder viewHolder, int direction) {
+    public void onItemCleared(final TViewHolder viewHolder, int direction) {
         final int adapterPosition = viewHolder.getAdapterPosition();
-        final T item = mItemDelegate.getItemAtAdapterPosition(adapterPosition);
+        final TItem item = mItemDelegate.getItemAtAdapterPosition(adapterPosition);
 
         displaySnackBarIfNeeded(viewHolder, item, adapterPosition, direction);
 
@@ -57,7 +57,7 @@ public abstract class DelegateSWAdapter<T> extends RecyclerView.Adapter<ViewHold
         notifyItemRemoved(adapterPosition);
     }
 
-    private void displaySnackBarIfNeeded(ViewHolder viewHolder, final T item, final int adapterPosition,
+    private void displaySnackBarIfNeeded(TViewHolder viewHolder, final TItem item, final int adapterPosition,
                                          int direction) {
         if(mSnackBarDataProvider != null && mSnackBarDataProvider.isUndoEnabled()) {
             final Snackbar snackbar = Snackbar
@@ -118,7 +118,7 @@ public abstract class DelegateSWAdapter<T> extends RecyclerView.Adapter<ViewHold
     }
 
     @Override
-    public String getSnackBarMessage(ViewHolder viewHolder, int direction) {
+    public String getSnackBarMessage(TViewHolder viewHolder, int direction) {
         if(mSnackBarDataProvider != null) {
             return mSnackBarDataProvider.getSnackBarMessage(direction);
         }
@@ -127,7 +127,7 @@ public abstract class DelegateSWAdapter<T> extends RecyclerView.Adapter<ViewHold
     }
 
     @Override
-    public String getUndoActionText(ViewHolder viewHolder, int direction) {
+    public String getUndoActionText(TViewHolder viewHolder, int direction) {
         if(mSnackBarDataProvider != null) {
             return mSnackBarDataProvider.getUndoActionText(direction);
         }
@@ -136,7 +136,7 @@ public abstract class DelegateSWAdapter<T> extends RecyclerView.Adapter<ViewHold
     }
 
     @Override
-    public int getSwipeDirs(ViewHolder viewHolder) {
+    public int getSwipeDirs(TViewHolder viewHolder) {
         return -1;
     }
 
@@ -144,15 +144,15 @@ public abstract class DelegateSWAdapter<T> extends RecyclerView.Adapter<ViewHold
         return mItemRemovalListener;
     }
 
-    public void setItemRemovalListener(SWItemRemovalListener<T> itemRemovalListener) {
+    public void setItemRemovalListener(SWItemRemovalListener<TItem> itemRemovalListener) {
         mItemRemovalListener = itemRemovalListener;
     }
 
-    public SWItemDelegate<T> getItemDelegate() {
+    public SWItemDelegate<TItem> getItemDelegate() {
         return mItemDelegate;
     }
 
-    public void setItemDelegate(SWItemDelegate<T> itemDelegate) {
+    public void setItemDelegate(SWItemDelegate<TItem> itemDelegate) {
         this.mItemDelegate = itemDelegate;
     }
 

--- a/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/adapter/SWAdapter.java
+++ b/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/adapter/SWAdapter.java
@@ -11,7 +11,7 @@ import io.huannguyen.swipeablerv.view.SWRecyclerView;
  * Created by huannguyen
  */
 
-public interface SWAdapter<T> {
+public interface SWAdapter<TItem, TViewHolder extends ViewHolder> {
 
     /**
      * Register an adapter with a {@link SWSnackBarDataProvider}
@@ -36,7 +36,7 @@ public interface SWAdapter<T> {
      *         <p>
      *         See {@link #setItemRemovalListener(SWItemRemovalListener)}
      */
-    void onItemCleared(final ViewHolder viewHolder, int direction);
+    void onItemCleared(final TViewHolder viewHolder, int direction);
 
     /**
      * Get a message being displayed on a {@link Snackbar} when an item is swiped away.
@@ -54,7 +54,7 @@ public interface SWAdapter<T> {
      *
      * @return a snack bar message
      */
-    String getSnackBarMessage(ViewHolder viewHolder, int direction);
+    String getSnackBarMessage(TViewHolder viewHolder, int direction);
 
     /**
      * Get the snack bar action text being displayed when an item is swiped away.
@@ -72,7 +72,7 @@ public interface SWAdapter<T> {
      *
      * @return an undo action text
      */
-    String getUndoActionText(ViewHolder viewHolder, int direction);
+    String getUndoActionText(TViewHolder viewHolder, int direction);
 
     /**
      * Get the supported swipe directions for a particular item in a {@link SWRecyclerView}.
@@ -90,9 +90,9 @@ public interface SWAdapter<T> {
      *
      * @return Swipe directions
      */
-    int getSwipeDirs(ViewHolder viewHolder);
+    int getSwipeDirs(TViewHolder viewHolder);
 
     SWItemRemovalListener getItemRemovalListener();
 
-    void setItemRemovalListener(SWItemRemovalListener<T> SWItemRemovalListener);
+    void setItemRemovalListener(SWItemRemovalListener<TItem> SWItemRemovalListener);
 }

--- a/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/adapter/StandardSWAdapter.java
+++ b/swipeable-rv/src/main/java/io/huannguyen/swipeablerv/adapter/StandardSWAdapter.java
@@ -7,13 +7,12 @@ import android.support.v7.widget.RecyclerView.ViewHolder;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.TextView;
-
-import java.util.List;
-
-import io.huannguyen.swipeablerv.SWItemRemovalListener;
 import io.huannguyen.swipeablerv.R;
+import io.huannguyen.swipeablerv.SWItemRemovalListener;
 import io.huannguyen.swipeablerv.SWSnackBarDataProvider;
 import io.huannguyen.swipeablerv.utils.ResourceUtils;
+
+import java.util.List;
 
 /**
  * Created by huannguyen
@@ -26,20 +25,21 @@ import io.huannguyen.swipeablerv.utils.ResourceUtils;
  * Subclass this class if that suits your implementation. Otherwise consider using {@link
  * DelegateSWAdapter} which does not directly manipulate the items if you need more flexibility.
  */
-public abstract class StandardSWAdapter<T> extends RecyclerView.Adapter<ViewHolder> implements
-                                                                                     io.huannguyen.swipeablerv.adapter.SWAdapter<T> {
-    protected List<T> mItems;
-    protected SWItemRemovalListener<T> mItemRemovalListener;
+public abstract class StandardSWAdapter<TItem, TViewHolder extends ViewHolder> extends RecyclerView.Adapter<TViewHolder>
+   implements io.huannguyen.swipeablerv.adapter.SWAdapter<TItem, TViewHolder>
+{
+    protected List<TItem> mItems;
+    protected SWItemRemovalListener<TItem> mItemRemovalListener;
     protected SWSnackBarDataProvider mSnackBarDataProvider;
 
-    protected StandardSWAdapter(List<T> items) {
+    protected StandardSWAdapter(List<TItem> items) {
         mItems = items;
     }
 
     @Override
-    public void onItemCleared(final ViewHolder viewHolder, final int direction) {
+    public void onItemCleared(final TViewHolder viewHolder, final int direction) {
         final int adapterPosition = viewHolder.getAdapterPosition();
-        final T item = mItems.get(adapterPosition);
+        final TItem item = mItems.get(adapterPosition);
 
         displaySnackBarIfNeeded(viewHolder, item, adapterPosition, direction);
 
@@ -50,7 +50,7 @@ public abstract class StandardSWAdapter<T> extends RecyclerView.Adapter<ViewHold
         notifyItemRemoved(adapterPosition);
     }
 
-    private void displaySnackBarIfNeeded(ViewHolder viewHolder, final T item, final int adapterPosition, int direction) {
+    private void displaySnackBarIfNeeded(TViewHolder viewHolder, final TItem item, final int adapterPosition, int direction) {
         if (mSnackBarDataProvider != null && mSnackBarDataProvider.isUndoEnabled()) {
             final Snackbar snackbar = Snackbar
                     .make(mSnackBarDataProvider.getView(), getSnackBarMessage(viewHolder, direction),
@@ -110,7 +110,7 @@ public abstract class StandardSWAdapter<T> extends RecyclerView.Adapter<ViewHold
     }
 
     @Override
-    public String getSnackBarMessage(ViewHolder viewHolder, int direction) {
+    public String getSnackBarMessage(TViewHolder viewHolder, int direction) {
         if(mSnackBarDataProvider != null) {
             return mSnackBarDataProvider.getSnackBarMessage(direction);
         }
@@ -119,7 +119,7 @@ public abstract class StandardSWAdapter<T> extends RecyclerView.Adapter<ViewHold
     }
 
     @Override
-    public String getUndoActionText(ViewHolder viewHolder, int direction) {
+    public String getUndoActionText(TViewHolder viewHolder, int direction) {
         if(mSnackBarDataProvider != null) {
             return mSnackBarDataProvider.getUndoActionText(direction);
         }
@@ -128,7 +128,7 @@ public abstract class StandardSWAdapter<T> extends RecyclerView.Adapter<ViewHold
     }
 
     @Override
-    public int getSwipeDirs(ViewHolder viewHolder) {
+    public int getSwipeDirs(TViewHolder viewHolder) {
         return -1;
     }
 
@@ -136,7 +136,7 @@ public abstract class StandardSWAdapter<T> extends RecyclerView.Adapter<ViewHold
         return mItemRemovalListener;
     }
 
-    public void setItemRemovalListener(SWItemRemovalListener<T> itemRemovalListener) {
+    public void setItemRemovalListener(SWItemRemovalListener<TItem> itemRemovalListener) {
         mItemRemovalListener = itemRemovalListener;
     }
 


### PR DESCRIPTION
Made the ViewHolder type generic in all interfaces which involve ViewHolder. This type is supposed to be generic for Adapters which gives back the appropriately-typed ViewHolder in all interface methods.

This IS a breaking change, ie: clients will have to specify the second generic parameter – but in turn they will not have to force-cast the view-holder type everywhere in their code.

NOTE: Also updated to latest library versions